### PR TITLE
PHP code MUST use the long <?php ?> tags or the short-echo <?= ?> tag…

### DIFF
--- a/Elama_PHP/ruleset.xml
+++ b/Elama_PHP/ruleset.xml
@@ -13,5 +13,8 @@
                     value="sizeof=>count,delete=>unset,print=>echo,die=>null,create_function=>null,exit=>null,eval=>null,var_dump=>null,print_r=>null,var_export=>null"/>
         </properties>
     </rule>
+    <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+        <severity>0</severity>
+    </rule>
 
 </ruleset>


### PR DESCRIPTION
…s; it MUST NOT use the other tag variations.